### PR TITLE
Paul/fg 8801 python example list mcap schemas with relevant detail

### DIFF
--- a/mcap/README.md
+++ b/mcap/README.md
@@ -1,0 +1,61 @@
+# MCAP Examples
+
+## List schemas in MCAP
+This example demonstrates how to list all unique schemas from an MCAP file, along with their associated message counts and metadata. The script extracts the schemas directly from the summary section of the MCAP file to ensure that all schemas are listed, including those without any associated messages.
+
+### Features:
+**List all unique schemas:** The script retrieves and lists schemas from the MCAP file.
+
+**Message count:** It counts and displays the number of messages associated with each schema.
+
+**Metadata display:** The metadata associated with each schema (if available) is also shown.
+
+### Prerequisites:
+- Python 3.x
+- mcap library installed. You can install it using:
+
+```bash
+pip install mcap
+```
+
+### How to Use:
+Clone the repository and navigate to the mcap directory:
+
+```bash
+git clone https://github.com/foxglove/examples.git
+cd examples/mcap
+```
+
+Run the script with your MCAP file as an argument:
+
+```bash
+python mcap_list_schemas_detail.py <path_to_mcap_file>
+```
+
+### Example Output:
+
+```bash
+Schema ID   Name                                                        Encoding    Message Count  Metadata                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+1           rcl_interfaces/msg/Log                                      ros2msg     39             {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+2           sensor_msgs/msg/Joy                                         ros2msg     0              {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+3           rosbag2_interfaces/msg/WriteSplitEvent                      ros2msg     0              {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+4           rcl_interfaces/msg/ParameterEvent                           ros2msg     0              {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+5           diagnostic_msgs/msg/DiagnosticArray                         ros2msg     74             {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+6           diagnostic_msgs/msg/DiagnosticStatus                        ros2msg     25             {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+7           sensor_msgs/msg/LaserScan                                   ros2msg     192            {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+8           std_msgs/msg/String                                         ros2msg     6              {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+9           tf2_msgs/msg/TFMessage                                      ros2msg     462            {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+10          geometry_msgs/msg/Twist                                     ros2msg     0              {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+11          sensor_msgs/msg/JointState                                  ros2msg     233            {"offered_qos_profiles": "- history: 3\n  depth: 0\n  rel ...
+```
+
+### Code Breakdown:
+**Schema Extraction:** The script uses the summary section of the MCAP file to retrieve all schemas, ensuring none are missed.
+
+**Message Counting:** It iterates over the messages in the MCAP file and counts how many messages are associated with each schema.
+
+**Metadata Handling:** Any available metadata for the schemas is displayed as key-value pairs.
+
+### Customization:
+Feel free to modify the script to suit your specific use case, such as adjusting the output format or adding additional schema details.

--- a/mcap/mcap_list_schemas_detail.py
+++ b/mcap/mcap_list_schemas_detail.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from mcap.reader import make_reader
 
@@ -22,14 +23,17 @@ def list_schemas_with_messages_and_metadata(mcap_file: str) -> None:
                 message_counts[schema_id] += 1
 
         # Display the schema information along with message count and metadata
-        print(f"{'Schema ID':<12}{'Name':<35}{'Encoding':<12}{'Message Count':<15}{'Metadata'}")
-        print('-' * 80)
+        print('\n')
+        print(f"{'Schema ID':<12}{'Name':<60}{'Encoding':<12}{'Message Count':<15}{'Metadata':<60}")
+        print('-' * 160)
         for schema_id in sorted(summary.schemas):
             schema = summary.schemas[schema_id]
             channel = summary.channels.get(schema_id, {})
             metadata = channel.metadata if channel else {}
-            metadata_str = ", ".join([f"{k}: {v}" for k, v in metadata.items()]) if metadata else "None"
-            print(f"{schema_id:<12}{schema.name:<35}{schema.encoding:<12}{message_counts[schema_id]:<15}{metadata_str}")
+            metadata_str = json.dumps(metadata)
+            if len(metadata_str) > 60:
+                metadata_str = metadata_str[:57] + " ..."
+            print(f"{schema_id:<12}{schema.name:<60}{schema.encoding:<12}{message_counts[schema_id]:<15}{metadata_str}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Truncate the output of metadata to keep a managable view. Added new doc specifically for this MCAP schema list. 